### PR TITLE
feat: polish home, blog nav, and gadgets UI

### DIFF
--- a/components/AsciiPortrait.tsx
+++ b/components/AsciiPortrait.tsx
@@ -25,16 +25,40 @@ export default function AsciiPortrait({
     if (!el) return;
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
 
-    const final = asciiPortrait;
-    const n = final.length;
-    const rows = final.split("\n").length;
+    const rawLines = asciiPortrait.split("\n");
+    const rows = rawLines.length;
+    const cols = rawLines.reduce((m, l) => Math.max(m, l.length), 0);
+    // The source art trims trailing blanks, so some rows are short — those
+    // missing cells never get a grid index and stay a "bald spot" the shimmer
+    // can't touch. Pad every non-empty row out to the full width (empty margin
+    // rows stay blank) so the whole silhouette reacts. Trailing spaces are
+    // invisible at rest, so this doesn't change the resting look.
+    const final = rawLines
+      .map((l) => (l.length > 0 ? l.padEnd(cols, " ") : l))
+      .join("\n");
+    const chars = final.split("");
+    const n = chars.length;
 
-    // Per-glyph reveal thresholds: a top-biased sparkle so the image condenses
-    // out of static rather than wiping in a straight line. Newlines stay fixed.
+    // Per-char grid coordinates (newlines flagged with row = -1) for the hover
+    // math below.
+    const rowOf = new Int16Array(n);
+    const colOf = new Int16Array(n);
+    for (let i = 0, r = 0, c = 0; i < n; i++) {
+      if (chars[i] === "\n") {
+        rowOf[i] = -1;
+        r++;
+        c = 0;
+      } else {
+        rowOf[i] = r;
+        colOf[i] = c++;
+      }
+    }
+
+    // --- intro reveal: a top-biased sparkle so the image condenses out of
+    // static rather than wiping in a straight line. Newlines stay fixed. ---
     const thr = new Float32Array(n);
-    let row = 0;
-    for (let i = 0; i < n; i++) {
-      if (final[i] === "\n") {
+    for (let i = 0, row = 0; i < n; i++) {
+      if (chars[i] === "\n") {
         thr[i] = -1;
         row++;
         continue;
@@ -43,25 +67,100 @@ export default function AsciiPortrait({
     }
 
     const ease = (t: number) => 1 - Math.pow(1 - t, 3);
-    let raf = 0;
-    let start = 0;
+    let introRaf = 0;
+    let introStart = 0;
+    let introDone = false;
 
-    const frame = (ts: number) => {
-      if (!start) start = ts;
-      const p = ease(Math.min(1, (ts - start) / DURATION));
+    const introFrame = (ts: number) => {
+      if (!introStart) introStart = ts;
+      const p = ease(Math.min(1, (ts - introStart) / DURATION));
       let out = "";
       for (let i = 0; i < n; i++) {
-        const c = final[i];
+        const c = chars[i];
         out += c === "\n" ? "\n" : p >= thr[i] ? c : noise();
       }
       el.textContent = out;
-      if (p < 1) raf = requestAnimationFrame(frame);
-      else el.textContent = final;
+      if (p < 1) introRaf = requestAnimationFrame(introFrame);
+      else {
+        el.textContent = final;
+        introDone = true;
+      }
     };
 
     el.textContent = final.replace(/[^\n]/g, noise);
-    raf = requestAnimationFrame(frame);
-    return () => cancelAnimationFrame(raf);
+    introRaf = requestAnimationFrame(introFrame);
+
+    // --- hover: glyphs within a small radius of the cursor scramble, then
+    // decay back to the portrait. A minimal, mouse-driven shimmer. ---
+    const disturb = new Float32Array(n); // 0..1 intensity per glyph
+    let hoverRaf = 0;
+    let hoverLast = 0;
+    let hoverActive = false;
+
+    const render = () => {
+      let out = "";
+      for (let i = 0; i < n; i++) {
+        const c = chars[i];
+        if (c === "\n") out += "\n";
+        else
+          out += disturb[i] > 0.02 && Math.random() < disturb[i] ? noise() : c;
+      }
+      el.textContent = out;
+    };
+
+    const hoverFrame = (ts: number) => {
+      if (!hoverLast) hoverLast = ts;
+      const decay = (ts - hoverLast) / 260; // settle back over ~260ms
+      hoverLast = ts;
+      let any = false;
+      for (let i = 0; i < n; i++) {
+        if (disturb[i] > 0) {
+          disturb[i] = Math.max(0, disturb[i] - decay);
+          if (disturb[i] > 0) any = true;
+        }
+      }
+      render();
+      if (any) hoverRaf = requestAnimationFrame(hoverFrame);
+      else {
+        el.textContent = final;
+        hoverActive = false;
+        hoverLast = 0;
+      }
+    };
+
+    const onMove = (e: PointerEvent) => {
+      if (!introDone) return; // let the reveal finish first
+      const rect = el.getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+      const cellW = rect.width / cols;
+      const cellH = rect.height / rows;
+      const mx = e.clientX - rect.left;
+      const my = e.clientY - rect.top;
+      const radius = Math.max(26, rect.width * 0.12);
+      for (let i = 0; i < n; i++) {
+        if (rowOf[i] < 0) continue;
+        const dx = (colOf[i] + 0.5) * cellW - mx;
+        const dy = (rowOf[i] + 0.5) * cellH - my;
+        const d = Math.hypot(dx, dy);
+        if (d < radius) {
+          const v = 1 - d / radius;
+          if (v > disturb[i]) disturb[i] = v;
+        }
+      }
+      if (!hoverActive) {
+        hoverActive = true;
+        hoverLast = 0;
+        hoverRaf = requestAnimationFrame(hoverFrame);
+      }
+    };
+
+    el.addEventListener("pointermove", onMove);
+
+    return () => {
+      cancelAnimationFrame(introRaf);
+      cancelAnimationFrame(hoverRaf);
+      el.removeEventListener("pointermove", onMove);
+    };
   }, []);
 
   return (

--- a/components/GadgetsBlueprint.tsx
+++ b/components/GadgetsBlueprint.tsx
@@ -1,6 +1,6 @@
 import { Link } from "@/components/_compat";
 import type { Tool as Gadget } from "@/types";
-import { Star, ArrowUpRight } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import GadgetGlyph from "@/components/GadgetGlyph";
 
 // tech / desk / other → friendlier zone titles for the drawing.
@@ -34,7 +34,7 @@ export default function GadgetsBlueprint({ gadgets }: { gadgets: Gadget[] }) {
           return (
             <section key={zone.key}>
               <div className="mb-5 flex items-center gap-3">
-                <span className="font-mono text-[11px] uppercase tracking-[0.25em] text-accent-primary/80">
+                <span className="font-mono text-[11px] uppercase tracking-[0.25em] text-white/90">
                   {zone.label}
                 </span>
                 <span className="h-px flex-1 bg-gradient-to-r from-white/15 to-transparent" />
@@ -57,7 +57,7 @@ export default function GadgetsBlueprint({ gadgets }: { gadgets: Gadget[] }) {
 }
 
 function Plate({ gadget }: { gadget: Gadget }) {
-  const { brand, name, what, favorite, link, icon } = gadget;
+  const { brand, name, what, link, icon } = gadget;
   const title = [brand, name].filter(Boolean).join(" ");
 
   const inner = (
@@ -68,12 +68,6 @@ function Plate({ gadget }: { gadget: Gadget }) {
       <Tick className="bottom-1.5 left-1.5 border-b border-l" />
       <Tick className="bottom-1.5 right-1.5 border-b border-r" />
 
-      {favorite && (
-        <Star
-          className="absolute right-3 top-3 h-3 w-3 fill-amber-300/80 text-amber-300/80"
-          aria-label="favorite"
-        />
-      )}
       {link && (
         <ArrowUpRight className="absolute bottom-3 right-3 h-3.5 w-3.5 text-light-fourth/50 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:translate-x-0.5 group-hover:text-accent-primary" />
       )}
@@ -86,9 +80,6 @@ function Plate({ gadget }: { gadget: Gadget }) {
         <h3 className="line-clamp-2 text-[13px] font-medium leading-snug text-white">
           {title}
         </h3>
-        <p className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-light-fourth">
-          {what}
-        </p>
       </div>
     </article>
   );

--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -24,7 +24,11 @@ const topCls = (active: boolean) =>
     active ? "text-accent-primary" : "text-light-secondary hover:text-white"
   }`;
 
-export default function SiteNav() {
+export default function SiteNav({
+  maxWidth = "max-w-3xl",
+}: {
+  maxWidth?: string;
+}) {
   const pathname = usePathname();
   const [menu, setMenu] = useState<null | "work" | "hobby">(null);
 
@@ -43,7 +47,9 @@ export default function SiteNav() {
       {/* Solid black + fixed: no translucent gray seam, and it stays pinned on
           overscroll instead of floating down over the background. */}
       <header className="fixed inset-x-0 top-0 z-40 border-b border-white/[0.06] bg-dark-primary animate-fade-in-down">
-        <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <div
+          className={`mx-auto flex ${maxWidth} items-center justify-between px-4 py-3 sm:px-6 lg:px-8`}
+        >
           <Link href="/" className="shrink-0 text-sm font-semibold text-white">
             <ScrambleText text={SHORT} className="md:hidden" />
             <ScrambleText text={NAME} className="hidden md:inline" />

--- a/components/Time.tsx
+++ b/components/Time.tsx
@@ -6,22 +6,25 @@ const DIGITS = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
 // One odometer reel: a stacked 0-9 column clipped to a single line, shifted so
 // the active digit shows. Value changes (per tick, or the initial roll-in from
-// 0) animate via the transform transition.
+// 0) animate via the transform transition. An invisible copy of the digit sits
+// in normal flow so the browser gives the reel a real text baseline (a clipped
+// inline-block otherwise baselines to its bottom edge, which nudges the digits
+// off the surrounding text — most visible at the small mobile size).
 function Reel({ value, animate }: { value: number; animate: boolean }) {
   return (
-    <span
-      className="inline-block h-[1em] overflow-hidden align-bottom leading-[1em]"
-      aria-hidden
-    >
-      <span
-        className="block transition-transform duration-[600ms] ease-out"
-        style={{ transform: `translateY(-${animate ? value : 0}em)` }}
-      >
-        {DIGITS.map((n) => (
-          <span key={n} className="block h-[1em] leading-[1em]">
-            {n}
-          </span>
-        ))}
+    <span className="relative inline-block h-[1em] leading-[1em]" aria-hidden>
+      <span className="invisible">{value}</span>
+      <span className="absolute inset-0 overflow-hidden">
+        <span
+          className="block transition-transform duration-[600ms] ease-out"
+          style={{ transform: `translateY(-${animate ? value : 0}em)` }}
+        >
+          {DIGITS.map((n) => (
+            <span key={n} className="block h-[1em] leading-[1em]">
+              {n}
+            </span>
+          ))}
+        </span>
       </span>
     </span>
   );

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -8,8 +8,9 @@ interface Props {
   noindex?: boolean;
   image?: string;
   ogType?: "website" | "article";
+  navMaxWidth?: string;
 }
-const { title, description, noindex, image, ogType } = Astro.props;
+const { title, description, noindex, image, ogType, navMaxWidth } = Astro.props;
 ---
 
 <Layout
@@ -20,6 +21,6 @@ const { title, description, noindex, image, ogType } = Astro.props;
   ogType={ogType}
 >
   <slot name="head" slot="head" />
-  <SiteNav client:load />
+  <SiteNav maxWidth={navMaxWidth} client:load />
   <slot />
 </Layout>

--- a/src/pages/writing/[slug].astro
+++ b/src/pages/writing/[slug].astro
@@ -64,6 +64,7 @@ const jsonLd = {
   description={post.excerpt || post.title}
   image={`/og/writing/${post.slug}.png`}
   ogType="article"
+  navMaxWidth="max-w-6xl"
 >
   <div class="mt-24 mb-16 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
     <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />


### PR DESCRIPTION
- nav: match navbar width to the article content on writing posts
- home: minimal cursor-proximity shimmer on the ASCII portrait; pad short rows so the whole silhouette reacts (no bald spot)
- home: seat the clock digit reels on the text baseline via an invisible in-flow anchor — fixes the mobile misalignment, now font-size independent
- gadgets: white section headers instead of purple; drop the star badge and the per-item category label